### PR TITLE
bug fix for generateDAAEncounterSet()

### DIFF
--- a/Encounter_Generation_Tool/generateDAAEncounterSet.m
+++ b/Encounter_Generation_Tool/generateDAAEncounterSet.m
@@ -517,7 +517,7 @@ function generateDAAEncounterSet(parameterFile)
         
         %If desired, convert trajectories to events
         if iniSettings.outputEvents
-            samples(j) = wpt2script(trajectoryOut1{j}, trajectoryOut2{j}, encIds(j), iniSettings.altLayers); %#okgrow
+            samples(j) = wpt2script(trajectoryOut1{j}, trajectoryOut2{j}, encIds(j), layers); %#okgrow
             
             %If encounters were generated from encounter model events,
             %output the original events. 


### PR DESCRIPTION
wpt2script() called by generateDAAEncounterSet() was expecting the last input to be a 2 X N column matrix of min and max altitude values. iniSettings.altLayers is a 1 X N array but reshaped into layers near the top of generateDAAEncounterSet(). By using iniSettings.altLayers instead of layers, wpt2script() was setting scriptedEncounter.altLayer to []